### PR TITLE
Initial update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,8 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
+    - wheel
   run:
     - python
     - numpy >=1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "accelerate" %}
 {% set version = "0.13.2" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -12,7 +11,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: true  # [py<36]
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
     - accelerate-config=accelerate.commands.config:main
@@ -21,14 +20,14 @@ build:
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.6
   run:
+    - python
     - numpy >=1.17
     - packaging >=20.0
     - psutil
     - pytorch >=1.4.0
-    - python >=3.6
     - pyyaml
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set name = "accelerate" %}
+{% set name = "huggingface_accelerate" %}
 {% set version = "0.15.0" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "accelerate" %}
-{% set version = "0.13.2" %}
+{% set version = "0.15.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/accelerate-{{ version }}.tar.gz
-  sha256: e22180d7094e4c1bfb05a2b078297c222f6b4fa595fde8916946c3f377cdf019
+  sha256: 438e25a01afa6e3ffbd25353e76a68be49677c3050f10bfac7beafaf53503efc
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,10 +50,18 @@ test:
 
 about:
   home: https://github.com/huggingface/accelerate
-  doc_url: https://huggingface.co/docs/accelerate
   summary: Training loop of PyTorch without boilerplate code
+  description: |
+    Accelerate was created for PyTorch users who like to write the training loop of PyTorch models but are reluctant to write and maintain the boilerplate code needed to use multi-GPUs/TPU/fp16.
+
+    Accelerate abstracts exactly and only the boilerplate code related to multi-GPUs/TPU/fp16 and leaves the rest of your code unchanged.
   license: Apache-2.0
   license_file: LICENSE
+  license_family: Apache
+  license_url: https://github.com/huggingface/accelerate/blob/v{{ version }}/LICENSE
+  doc_url: https://huggingface.co/docs/accelerate/index
+  doc_source_url: https://github.com/huggingface/accelerate/tree/main/docs/source
+  dev_url: https://github.com/huggingface/accelerate
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<36]
+  skip: true  # [py<37]
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
     - accelerate-config=accelerate.commands.config:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,8 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  # MacOS and Windows are currently missing USE_DISTRIBUTED flag in pytorch.
+  skip: true  # [py<37 or osx or win]
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
     - accelerate-config=accelerate.commands.config:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,8 @@ requirements:
     - psutil
     - pytorch >=1.4.0,<3
     - pyyaml
+    # https://github.com/huggingface/accelerate/blob/v0.15.0/src/accelerate/utils/versions.py#L23
+    - importlib_metadata # [py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,11 +55,12 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
-  license_url: https://github.com/huggingface/accelerate/blob/v{{ version }}/LICENSE
   doc_url: https://huggingface.co/docs/accelerate/index
-  doc_source_url: https://github.com/huggingface/accelerate/tree/main/docs/source
   dev_url: https://github.com/huggingface/accelerate
 
 extra:
   recipe-maintainers:
     - thewchan
+  skip-lints:
+    - missing_doc_source_url
+    - missing_license_url

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,12 +43,6 @@ test:
     - accelerate --help
     - accelerate-config --help
     - accelerate-launch --help
-  requires:
-    - datasets
-    - pip
-    - sentencepiece
-    - transformers
-    - tokenizers !=0.11.3,<0.13,>=0.11.1
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
-{% set name = "huggingface_accelerate" %}
+{% set name = "accelerate" %}
 {% set version = "0.15.0" %}
 
 package:
-  name: {{ name|lower }}
+  name: huggingface_{{ name|lower }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - numpy >=1.17
     - packaging >=20.0
     - psutil
-    - pytorch >=1.4.0
+    - pytorch >=1.4.0,<3
     - pyyaml
 
 test:


### PR DESCRIPTION
# Accelerate 0.15.0

upstream: https://github.com/huggingface/accelerate/tree/v0.15.0
jira: https://anaconda.atlassian.net/browse/PKG-684
`setup.py`: https://github.com/huggingface/accelerate/blob/v0.15.0/setup.py#L54
license: https://github.com/huggingface/accelerate/blob/v0.15.0/LICENSE

## Changes
- Forked from CF
- Remove noarch, add python tools
- Update pinnings from upstream
- Update about section

## Notes
- This package is not currently on defaults
- MacOS and Windows are skipped until `pytorch` can be built with the flag `USE_DISTRIBUTED=1` 
- Renamed to `huggingface_accelerate` to not be confused with the [macOS built-in math library](https://developer.apple.com/documentation/accelerate)