### PR TITLE
0.21.0 update, add Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     # pytorch first built with USE_DISTRIBUTED=1 at v2.0.1 for win/osx.
     - pytorch >=2.0.1  # [win or osx]
     - pyyaml
-    # https://github.com/huggingface/accelerate/blob/v0.20.3/src/accelerate/utils/versions.py#L23
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,9 @@ requirements:
     - numpy >=1.17
     - packaging >=20.0
     - psutil
-    - pytorch >=1.10.0
+    - pytorch >=1.10.0  # [linux]
+    # pytorch first built with USE_DISTRIBUTED=1 at v2.0.1 for win/osx.
+    - pytorch >=2.0.1  # [win or osx]
     - pyyaml
     # https://github.com/huggingface/accelerate/blob/v0.20.3/src/accelerate/utils/versions.py#L23
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
+  skip: true  # [py<38]
   # ppc64le is missing pytorch for 3.11
   skip: true  # [py>310 and (linux and ppc64le)]
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "accelerate" %}
-{% set version = "0.20.3" %}
+{% set version = "0.21.0" %}
 
 package:
   name: huggingface_{{ name|lower }}
@@ -7,12 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/accelerate-{{ version }}.tar.gz
-  sha256: 79a896978c20dac270083d42bf033f4c9a80dcdd6b946f1ca92d8d6d0f0f5ba9
+  sha256: e2959a0bf74d97c0b3c0e036ed96065142a060242281d27970d4c4e34f11ca59
 
 build:
   number: 0
-  # Windows is currently missing USE_DISTRIBUTED flag in pytorch.
-  skip: true  # [py<37 or win]
+  skip: true  # [py<37]
   # ppc64le is missing pytorch for 3.11
   skip: true  # [py>310 and (linux and ppc64le)]
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,9 @@ requirements:
     - numpy >=1.17
     - packaging >=20.0
     - psutil
-    - pytorch >=1.6.0
+    - pytorch >=1.10.0
     - pyyaml
     # https://github.com/huggingface/accelerate/blob/v0.20.3/src/accelerate/utils/versions.py#L23
-    - importlib_metadata # [py<38]
 
 test:
   requires:


### PR DESCRIPTION
[Upstream Repo](https://github.com/huggingface/accelerate)
[Jira issue](https://anaconda.atlassian.net/browse/PKG-2472)

`accelerate` -> `diffusers`

- Enabled building for Windows/OSX with `pytorch 2.0.1`
- Updated dependency pinnings.