### PR TITLE
PKG-5564: Update huggingface_accelerate to 0.33.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,6 +50,7 @@ test:
     - accelerate
   commands:
     - pip check
+    - set "PYTHONIOENCODING=utf8"  # [win]
     - accelerate --help
     - accelerate-config --help
     - accelerate-launch --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
     - accelerate-config=accelerate.commands.config:main
     - accelerate-estimate-memory=accelerate.commands.estimate:main
     - accelerate-launch=accelerate.commands.launch:main
+    - accelerate-merge-weights=accelerate.commands.merge:main   
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,14 +46,6 @@ requirements:
 test:
   requires:
     - pip
-    - datasets
-    - evaluate
-    - pip
-    - pytest
-    - scipy
-    - scikit-learn
-    - transformers
-    - tqdm
   imports:
     - accelerate
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ build:
     - accelerate-config=accelerate.commands.config:main
     - accelerate-estimate-memory=accelerate.commands.estimate:main
     - accelerate-launch=accelerate.commands.launch:main
-    - accelerate-merge-weights=accelerate.commands.merge:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -47,15 +46,22 @@ requirements:
 test:
   requires:
     - pip
+    - datasets
+    - evaluate
+    - pip
+    - pytest
+    - scipy
+    - scikit-learn
+    - transformers
+    - tqdm
   imports:
     - accelerate
   commands:
     - pip check
     - accelerate --help
     - accelerate-config --help
-    - accelerate-estimate-memory --help
     - accelerate-launch --help
-    - accelerate-merge-weights --help
+    - accelerate-estimate-memory --help
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   skip: true  # [py<38]
   # s390x is missing safetensors for 0.4.4
-  skip: True  # [linux and s390x]
+  skip: true  # [linux and s390x]
   # ppc64le is missing pytorch for 3.11
   skip: true  # [py>310 and (linux and ppc64le)]
   entry_points:
@@ -54,7 +54,7 @@ test:
     - accelerate --help
     - accelerate-config --help
     - accelerate-estimate-memory --help
-    - accelerate-launch --version
+    - accelerate-launch --help
     - accelerate-merge-weights --help
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - python
     # https://github.com/huggingface/accelerate/blob/665d5180fcc01d5700f7a9aa3f9bdb75c6055dce/src/accelerate/utils/torch_xla.py#L18
     - setuptools
-    - numpy 1.17,<2.0.0
+    - numpy >=1.17,<2.0.0
     - packaging >=20.0
     - psutil
     - pytorch >=1.10.0  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,7 @@ test:
     - accelerate-config --help
     - accelerate-launch --help
     - accelerate-estimate-memory --help
+    - accelerate-merge-weights --help
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "accelerate" %}
-{% set version = "0.21.0" %}
+{% set version = "0.33.0" %}
 
 package:
   name: huggingface_{{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/accelerate-{{ version }}.tar.gz
-  sha256: e2959a0bf74d97c0b3c0e036ed96065142a060242281d27970d4c4e34f11ca59
+  sha256: 11ba481ed6ea09191775df55ce464aeeba67a024bd0261a44b77b30fb439e26a
 
 build:
   number: 0
@@ -17,7 +17,9 @@ build:
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
     - accelerate-config=accelerate.commands.config:main
+    - accelerate-estimate-memory=accelerate.commands.estimate:main
     - accelerate-launch=accelerate.commands.launch:main
+    - accelerate-merge-weights=accelerate.commands.merge:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
@@ -36,19 +38,22 @@ requirements:
     - pytorch >=1.10.0  # [linux]
     # pytorch first built with USE_DISTRIBUTED=1 at v2.0.1 for win/osx.
     - pytorch >=2.0.1  # [win or osx]
+    - huggingface_hub >=0.21.0 
     - pyyaml
+    - safetensors >=0.3.1
 
 test:
   requires:
     - pip
   imports:
     - accelerate
-    - accelerate.commands
   commands:
     - pip check
     - accelerate --help
     - accelerate-config --help
+    - accelerate-estimate-memory --help
     - accelerate-launch --help
+    - accelerate-merge-weights --help
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   skip: true  # [py<38]
   # s390x is missing safetensors for 0.4.4
-  skip: true  # [s390x]
+  skip: True  # [linux and s390x]
   # ppc64le is missing pytorch for 3.11
   skip: true  # [py>310 and (linux and ppc64le)]
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - python
     # https://github.com/huggingface/accelerate/blob/665d5180fcc01d5700f7a9aa3f9bdb75c6055dce/src/accelerate/utils/torch_xla.py#L18
     - setuptools
-    - numpy >=1.17
+    - numpy 1.17,<2.0.0
     - packaging >=20.0
     - psutil
     - pytorch >=1.10.0  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,7 @@ test:
     - accelerate --help
     - accelerate-config --help
     - accelerate-estimate-memory --help
-    - accelerate-launch --help
+    - accelerate-launch --version
     - accelerate-merge-weights --help
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   skip: true  # [py<38]
+  # s390x is missing safetensors for 0.4.4
+  skip: true  # [s390x]
   # ppc64le is missing pytorch for 3.11
   skip: true  # [py>310 and (linux and ppc64le)]
   entry_points:


### PR DESCRIPTION
huggingface_accelerate 0.33.0

**Destination channel:** defaults

### Links

- [PKG-5564](https://anaconda.atlassian.net/browse/PKG-5564) 
- [Upstream repository](https://github.com/huggingface/accelerate)
- [Upstream changelog/diff](https://github.com/huggingface/accelerate/releases)
- Relevant dependency PRs:
  - Dependency for https://github.com/AnacondaRecipes/transformers-feedstock/pull/13

### Explanation of changes:

- Update to 0.33.0
- Update entry points and tests to match upstream


[PKG-5564]: https://anaconda.atlassian.net/browse/PKG-5564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ