### PR TITLE
v1.4.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ build_env_vars:
 
 channels:
   - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr9/8468f66
+  - https://staging.continuum.io/prefect/fs/safetensors-feedstock/pr9/c8e46a9

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/huggingface_hub-feedstock/pr9/8468f66

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<39]
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
     - accelerate-config=accelerate.commands.config:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "accelerate" %}
-{% set version = "1.0.1" %}
+{% set version = "1.4.0" %}
 
 package:
   name: huggingface_{{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e8f95fc2db14915dc0a9182edfcf3068e5ddb2fa310b583717ad44e5c442399c
+  sha256: 37d413e1b64cb8681ccd2908ae211cf73e13e6e636a2f598a96eccaa538773a5
 
 build:
   number: 0
@@ -31,7 +31,7 @@ requirements:
     - numpy >=1.17,<3.0.0
     - packaging >=20.0
     - psutil
-    - pytorch >=1.10.0  # [linux]
+    - pytorch >=2.0.0  # [linux]
     # pytorch first built with USE_DISTRIBUTED=1 at v2.0.1 for win/osx.
     - pytorch >=2.0.1  # [win or osx]
     - huggingface_hub >=0.21.0


### PR DESCRIPTION
huggingface-accelerate v1.4.0

**Destination channel:** defaults

### Links

- [PKG-7176](https://anaconda.atlassian.net/browse/PKG-7176) 
- [Upstream repository](https://github.com/huggingface/accelerate/tree/v1.4.0)

### Explanation of changes:
- Bump Version and SHA
- Build for python 3.13 and limit to >=3.9


[PKG-7176]: https://anaconda.atlassian.net/browse/PKG-7176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ