### PR TITLE
v1.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,11 @@ requirements:
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_convert_to_fp32 " %}                           # [py>=314 or win]
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_send_to_device_compiles " %}                   # [py>=314 or win]
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_keep_torch_compile " %}   # [py>=314 or win]
-{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_remove_torch_compile" %}  # [py>=314 or win]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_remove_torch_compile " %}  # [py>=314 or win]
+
+# Windows has no fork support; debug_launcher hard-codes start_method="fork" in these scheduler tests
+{% set skip_compile = skip_compile + "--deselect tests/test_scheduler.py::SchedulerTester::test_lambda_scheduler_not_step_with_optimizer_multiprocess " %}  # [win]
+{% set skip_compile = skip_compile + "--deselect tests/test_scheduler.py::SchedulerTester::test_lambda_scheduler_step_with_optimizer_multiprocess" %}        # [win]
 
 test:
   source_files:
@@ -71,7 +75,7 @@ test:
     # by upstream decorators (require_non_cpu, require_tpu, etc.).
     # Omit files that require optional heavy deps (bitsandbytes, FP8, trackers,
     # SageMaker, DeepSpeed, FSDP, TP) or full training examples.
-    - pytest tests/test_dataclasses.py tests/test_imports.py tests/test_logging.py tests/test_utils.py tests/test_scheduler.py tests/test_metrics.py tests/test_optimizer.py tests/test_quantization.py -v -x --no-header -rN {{ skip_compile }}
+    - pytest tests/test_dataclasses.py tests/test_imports.py tests/test_logging.py tests/test_utils.py tests/test_scheduler.py tests/test_metrics.py tests/test_optimizer.py tests/test_quantization.py -v --no-header -rf {{ skip_compile }}
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,11 @@ requirements:
     - safetensors >=0.4.3
 
 test:
+{% if win %}
+  # Ensure torch.distributed / elastic workers see USE_LIBUV=0 (PyTorch win builds without libuv).
+  script_env:
+    - USE_LIBUV=0
+{% endif %}
   # Globs are relative to the extracted source root; required for upstream pytest files to
   # exist under $SRC_DIR after the work directory is moved away.
   source_files:
@@ -71,15 +76,15 @@ test:
     - accelerate-merge-weights --help
     # PyTorch disables torch.compile on Python 3.14+; skip those tests and MPS env-var test (no torch.mps.set_device).
     # Skip tests/fsdp: FSDP plugin paths require CUDA/NPU/XPU/etc. for sync_module_states, not MPS (fails on osx-arm64).
-    # Linux CI: force Gloo over loopback (avoids connectFullMesh / wrong iface in multi-CPU tests).
-    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp  # [linux and py<314]
-    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [linux and py>=314]
+    # Linux CI: Gloo over loopback; deselect flaky multi-CPU test_ops; gxx test deps set CC — skip patch_environment check.
+    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp --deselect=tests/test_cpu.py::MultiCPUTester::test_ops --deselect=tests/test_utils.py::UtilsTester::test_patch_environment_key_exists  # [linux and py<314]
+    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp --deselect=tests/test_cpu.py::MultiCPUTester::test_ops --deselect=tests/test_utils.py::UtilsTester::test_patch_environment_key_exists -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [linux and py>=314]
     - pytest tests -v --ignore=tests/fsdp  # [osx and py<314]
     - pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [osx and py>=314]
     # Windows: PyTorch TCPStore may require USE_LIBUV=0; upstream debug_launcher uses fork (unsupported) — ignore those modules;
     # skip checkpoint tests that hit PermissionError on short Windows temp paths and Inductor-only FP32 test.
-    - set USE_LIBUV=0 && pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1 or test_convert_to_fp32)"  # [win and py<314]
-    - set USE_LIBUV=0 && pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device or test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1)"  # [win and py>=314]
+    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1 or test_convert_to_fp32)"  # [win and py<314]
+    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device or test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1)"  # [win and py>=314]
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,16 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  # GitHub archive (not PyPI sdist): upstream tests need `tests/test_configs/` and `examples/`,
-  # which are omitted from the PyPI tarball.
-  url: https://github.com/huggingface/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 7c0cf5f8a0871e43e497ada6602fdc7853417731101e1d62aa6a376c1567d27a
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236
 
 build:
   number: 0
-  # Allow bundling paths listed under `test/source_files` into the package's `info/test/`
-  # (extracted to $SRC_DIR during the test phase).
-  copy_test_source_files: true
   skip: true  # [py<310]
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
@@ -43,27 +38,25 @@ requirements:
     - pyyaml
     - safetensors >=0.4.3
 
+{% set skip_compile = "" %}
+
+# conda-build always injects CC (C compiler path); test assumes CC is absent, so it always fails here
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_patch_environment_key_exists " %}
+
+# torch.compile is unsupported on Python 3.14+; deselect those tests until pytorch catches up
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_convert_to_fp32 " %}                           # [py>=314]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_send_to_device_compiles " %}                   # [py>=314]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_keep_torch_compile " %}   # [py>=314]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_remove_torch_compile" %}  # [py>=314]
+
 test:
-  # Per output variant (not host machine): set USE_LIBUV for Windows test subprocesses.
-{% if target_platform is defined and target_platform.startswith('win') %}
-  script_env:
-    - USE_LIBUV=0
-{% endif %}
-  # Globs are relative to the extracted source root; required for upstream pytest files to
-  # exist under $SRC_DIR after the work directory is moved away.
   source_files:
-    - tests
-    - examples
+    - tests/
   requires:
     - pip
     - pytest
-    # Upstream `extras["test_prod"]` (used by many tests for collection / parametrization).
     - parameterized
-    # `tests/test_big_modeling.py` imports transformers at module import time.
-    - transformers
-    # `torch.compile(..., fullgraph=True)` in `test_convert_to_fp32` needs a working C++ toolchain for Inductor.
-    - gxx_linux-64  # [linux64]
-    - gxx_linux-aarch64  # [aarch64 and linux]
+    - cxx-compiler
   imports:
     - accelerate
   commands:
@@ -74,18 +67,11 @@ test:
     - accelerate-launch --help
     - accelerate-estimate-memory --help
     - accelerate-merge-weights --help
-    # PyTorch disables torch.compile on Python 3.14+; skip those tests and MPS env-var test (no torch.mps.set_device).
-    # Skip tests/fsdp: FSDP plugin paths require CUDA/NPU/XPU/etc. for sync_module_states, not MPS (fails on osx-arm64).
-    # Linux CI: Gloo over loopback; deselect flaky multi-CPU test_ops; gxx test deps set CC — skip patch_environment check.
-    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp --deselect=tests/test_cpu.py::MultiCPUTester::test_ops --deselect=tests/test_utils.py::UtilsTester::test_patch_environment_key_exists  # [linux and py<314]
-    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp --deselect=tests/test_cpu.py::MultiCPUTester::test_ops --deselect=tests/test_utils.py::UtilsTester::test_patch_environment_key_exists -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [linux and py>=314]
-    - pytest tests -v --ignore=tests/fsdp  # [osx and py<314]
-    - pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [osx and py>=314]
-    # Windows: fork-based debug_launcher tests ignored; temp-path checkpoint + Inductor skips in -k.
-    # Deselect test_config_compatibility: torchrun/elastic TCPStore still requests libuv on some win PyTorch builds
-    # even when USE_LIBUV=0 is set (SUBFAILED on latest_fsdp.yaml).
-    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py --deselect=tests/test_cli.py::AccelerateLauncherTester::test_config_compatibility -k "not (test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1 or test_convert_to_fp32)"  # [win and py<314]
-    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py --deselect=tests/test_cli.py::AccelerateLauncherTester::test_config_compatibility -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device or test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1)"  # [win and py>=314]
+    # Run CPU-safe upstream tests; GPU/TPU/distributed tests are auto-skipped
+    # by upstream decorators (require_non_cpu, require_tpu, etc.).
+    # Omit files that require optional heavy deps (bitsandbytes, FP8, trackers,
+    # SageMaker, DeepSpeed, FSDP, TP) or full training examples.
+    - pytest tests/test_dataclasses.py tests/test_imports.py tests/test_logging.py tests/test_utils.py tests/test_scheduler.py tests/test_metrics.py tests/test_optimizer.py tests/test_quantization.py -v -x --no-header -rN {{ skip_compile }}
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,8 @@ requirements:
     - safetensors >=0.4.3
 
 test:
-{% if win %}
-  # Ensure torch.distributed / elastic workers see USE_LIBUV=0 (PyTorch win builds without libuv).
+  # Per output variant (not host machine): set USE_LIBUV for Windows test subprocesses.
+{% if target_platform is defined and target_platform.startswith('win') %}
   script_env:
     - USE_LIBUV=0
 {% endif %}
@@ -81,10 +81,11 @@ test:
     - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp --deselect=tests/test_cpu.py::MultiCPUTester::test_ops --deselect=tests/test_utils.py::UtilsTester::test_patch_environment_key_exists -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [linux and py>=314]
     - pytest tests -v --ignore=tests/fsdp  # [osx and py<314]
     - pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [osx and py>=314]
-    # Windows: PyTorch TCPStore may require USE_LIBUV=0; upstream debug_launcher uses fork (unsupported) — ignore those modules;
-    # skip checkpoint tests that hit PermissionError on short Windows temp paths and Inductor-only FP32 test.
-    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1 or test_convert_to_fp32)"  # [win and py<314]
-    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device or test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1)"  # [win and py>=314]
+    # Windows: fork-based debug_launcher tests ignored; temp-path checkpoint + Inductor skips in -k.
+    # Deselect test_config_compatibility: torchrun/elastic TCPStore still requests libuv on some win PyTorch builds
+    # even when USE_LIBUV=0 is set (SUBFAILED on latest_fsdp.yaml).
+    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py --deselect=tests/test_cli.py::AccelerateLauncherTester::test_config_compatibility -k "not (test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1 or test_convert_to_fp32)"  # [win and py<314]
+    - pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py --deselect=tests/test_cli.py::AccelerateLauncherTester::test_config_compatibility -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device or test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1)"  # [win and py>=314]
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,6 +56,9 @@ test:
     - parameterized
     # `tests/test_big_modeling.py` imports transformers at module import time.
     - transformers
+    # `torch.compile(..., fullgraph=True)` in `test_convert_to_fp32` needs a working C++ toolchain for Inductor.
+    - gxx_linux-64  # [linux64]
+    - gxx_linux-aarch64  # [aarch64 and linux]
   imports:
     - accelerate
   commands:
@@ -68,8 +71,15 @@ test:
     - accelerate-merge-weights --help
     # PyTorch disables torch.compile on Python 3.14+; skip those tests and MPS env-var test (no torch.mps.set_device).
     # Skip tests/fsdp: FSDP plugin paths require CUDA/NPU/XPU/etc. for sync_module_states, not MPS (fails on osx-arm64).
-    - pytest tests -v --ignore=tests/fsdp  # [py<314]
-    - pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [py>=314]
+    # Linux CI: force Gloo over loopback (avoids connectFullMesh / wrong iface in multi-CPU tests).
+    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp  # [linux and py<314]
+    - export GLOO_SOCKET_IFNAME=lo && pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [linux and py>=314]
+    - pytest tests -v --ignore=tests/fsdp  # [osx and py<314]
+    - pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [osx and py>=314]
+    # Windows: PyTorch TCPStore may require USE_LIBUV=0; upstream debug_launcher uses fork (unsupported) — ignore those modules;
+    # skip checkpoint tests that hit PermissionError on short Windows temp paths and Inductor-only FP32 test.
+    - set USE_LIBUV=0 && pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1 or test_convert_to_fp32)"  # [win and py<314]
+    - set USE_LIBUV=0 && pytest tests -v --ignore=tests/fsdp --ignore=tests/test_cpu.py --ignore=tests/test_grad_sync.py --ignore=tests/test_scheduler.py -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device or test_load_checkpoint_in_model_dtype or test_load_checkpoint_in_model_unexpected_keys_0 or test_load_checkpoint_in_model_unexpected_keys_1)"  # [win and py>=314]
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,9 +49,8 @@ requirements:
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_keep_torch_compile " %}   # [py>=314 or win]
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_remove_torch_compile " %}  # [py>=314 or win]
 
-# Windows has no fork support; debug_launcher hard-codes start_method="fork" in these scheduler tests
-{% set skip_compile = skip_compile + "--deselect tests/test_scheduler.py::SchedulerTester::test_lambda_scheduler_not_step_with_optimizer_multiprocess " %}  # [win]
-{% set skip_compile = skip_compile + "--deselect tests/test_scheduler.py::SchedulerTester::test_lambda_scheduler_step_with_optimizer_multiprocess" %}        # [win]
+# Windows has no fork support; every test in test_scheduler.py uses debug_launcher(start_method="fork")
+{% set skip_compile = skip_compile + "--ignore=tests/test_scheduler.py" %}  # [win]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,11 +6,16 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236
+  # GitHub archive (not PyPI sdist): upstream tests need `tests/test_configs/` and `examples/`,
+  # which are omitted from the PyPI tarball.
+  url: https://github.com/huggingface/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 7c0cf5f8a0871e43e497ada6602fdc7853417731101e1d62aa6a376c1567d27a
 
 build:
   number: 0
+  # Allow bundling paths listed under `test/source_files` into the package's `info/test/`
+  # (extracted to $SRC_DIR during the test phase).
+  copy_test_source_files: true
   skip: true  # [py<310]
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
@@ -39,8 +44,18 @@ requirements:
     - safetensors >=0.4.3
 
 test:
+  # Globs are relative to the extracted source root; required for upstream pytest files to
+  # exist under $SRC_DIR after the work directory is moved away.
+  source_files:
+    - tests
+    - examples
   requires:
     - pip
+    - pytest
+    # Upstream `extras["test_prod"]` (used by many tests for collection / parametrization).
+    - parameterized
+    # `tests/test_big_modeling.py` imports transformers at module import time.
+    - transformers
   imports:
     - accelerate
   commands:
@@ -51,6 +66,10 @@ test:
     - accelerate-launch --help
     - accelerate-estimate-memory --help
     - accelerate-merge-weights --help
+    # PyTorch disables torch.compile on Python 3.14+; skip those tests and MPS env-var test (no torch.mps.set_device).
+    # Skip tests/fsdp: FSDP plugin paths require CUDA/NPU/XPU/etc. for sync_module_states, not MPS (fails on osx-arm64).
+    - pytest tests -v --ignore=tests/fsdp  # [py<314]
+    - pytest tests -v --ignore=tests/fsdp -k "not (test_can_unwrap_distributed_compiled_model_keep_torch_compile or test_can_unwrap_distributed_compiled_model_remove_torch_compile or test_extract_model_from_parallel_partial_compile or test_convert_to_fp32 or test_dynamo_extract_model_keep_torch_compile or test_dynamo_extract_model_remove_torch_compile or test_send_to_device_compiles or test_env_var_device)"  # [py>=314]
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,10 +44,10 @@ requirements:
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_patch_environment_key_exists " %}
 
 # torch.compile is unsupported on Python 3.14+; deselect those tests until pytorch catches up
-{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_convert_to_fp32 " %}                           # [py>=314]
-{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_send_to_device_compiles " %}                   # [py>=314]
-{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_keep_torch_compile " %}   # [py>=314]
-{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_remove_torch_compile" %}  # [py>=314]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_convert_to_fp32 " %}                           # [py>=314 or win]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_send_to_device_compiles " %}                   # [py>=314 or win]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_keep_torch_compile " %}   # [py>=314 or win]
+{% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_remove_torch_compile" %}  # [py>=314 or win]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,8 +49,10 @@ requirements:
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_keep_torch_compile " %}   # [py>=314 or win]
 {% set skip_compile = skip_compile + "--deselect tests/test_utils.py::UtilsTester::test_dynamo_extract_model_remove_torch_compile " %}  # [py>=314 or win]
 
-# Windows has no fork support; every test in test_scheduler.py uses debug_launcher(start_method="fork")
-{% set skip_compile = skip_compile + "--ignore=tests/test_scheduler.py" %}  # [win]
+# Run subset of tests for faster builds.
+{% set test_files = "tests/test_dataclasses.py tests/test_imports.py tests/test_logging.py tests/test_utils.py tests/test_metrics.py tests/test_optimizer.py tests/test_quantization.py" %}
+# Every test in test_scheduler.py uses debug_launcher(start_method="fork"); Windows only supports "spawn"
+{% set test_files = test_files + " tests/test_scheduler.py" %}  # [unix]
 
 test:
   source_files:
@@ -74,7 +76,7 @@ test:
     # by upstream decorators (require_non_cpu, require_tpu, etc.).
     # Omit files that require optional heavy deps (bitsandbytes, FP8, trackers,
     # SageMaker, DeepSpeed, FSDP, TP) or full training examples.
-    - pytest tests/test_dataclasses.py tests/test_imports.py tests/test_logging.py tests/test_utils.py tests/test_scheduler.py tests/test_metrics.py tests/test_optimizer.py tests/test_quantization.py -v --no-header -rf {{ skip_compile }}
+    - pytest {{ test_files }} -v --no-header -rf {{ skip_compile }}
 
 about:
   home: https://github.com/huggingface/accelerate

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "accelerate" %}
-{% set version = "1.4.0" %}
+{% set version = "1.13.0" %}
 
 package:
   name: huggingface_{{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 37d413e1b64cb8681ccd2908ae211cf73e13e6e636a2f598a96eccaa538773a5
+  sha256: d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   entry_points:
     - accelerate=accelerate.commands.accelerate_cli:main
     - accelerate-config=accelerate.commands.config:main
@@ -28,7 +28,7 @@ requirements:
     - wheel
   run:
     - python
-    - numpy >=1.17,<3.0.0
+    - numpy >=1.17
     - packaging >=20.0
     - psutil
     - pytorch >=2.0.0  # [linux]


### PR DESCRIPTION
huggingface_accelerate v1.13.0
**Destination channel:**  defaults

### Links

- [PKG-13815](https://anaconda.atlassian.net/browse/PKG-13815)
- [Upstream repository](https://github.com/huggingface/accelerate/tree/v1.13.0)
- [Upstream changelog/diff](https://github.com/huggingface/accelerate/releases)


### Explanation of changes:

- Bump version and SHA
- loosen numpy pinning per upstream


[PKG-13815]: https://anaconda.atlassian.net/browse/PKG-13815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ