### PR TITLE
Make multi-output, also output `accelerate`

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,42 +1,6 @@
 {% set name = "accelerate" %}
 {% set version = "1.13.0" %}
 
-package:
-  name: huggingface_{{ name|lower }}
-  version: {{ version }}
-
-source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236
-
-build:
-  number: 0
-  skip: true  # [py<310]
-  entry_points:
-    - accelerate=accelerate.commands.accelerate_cli:main
-    - accelerate-config=accelerate.commands.config:main
-    - accelerate-estimate-memory=accelerate.commands.estimate:main
-    - accelerate-launch=accelerate.commands.launch:main
-    - accelerate-merge-weights=accelerate.commands.merge:main
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-
-requirements:
-  host:
-    - python
-    - pip
-    - setuptools
-    - wheel
-  run:
-    - python
-    - numpy >=1.17
-    - packaging >=20.0
-    - psutil
-    - pytorch >=2.0.0  # [linux]
-    # pytorch first built with USE_DISTRIBUTED=1 at v2.0.1 for win/osx.
-    - pytorch >=2.0.1  # [win or osx]
-    - huggingface_hub >=0.21.0
-    - pyyaml
-    - safetensors >=0.4.3
 
 {% set skip_compile = "" %}
 
@@ -54,29 +18,86 @@ requirements:
 # Every test in test_scheduler.py uses debug_launcher(start_method="fork"); Windows only supports "spawn"
 {% set test_files = test_files + " tests/test_scheduler.py" %}  # [unix]
 
-test:
-  source_files:
-    - tests/
-  requires:
+package:
+  name: huggingface_{{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236
+
+build:
+  number: 1
+  skip: true  # [py<310]
+
+requirements:
+  host:
+    - python
     - pip
-    - pytest
-    - parameterized
-    - cxx-compiler
-  imports:
-    - accelerate
-  commands:
-    - pip check
-    - set "PYTHONIOENCODING=utf8"  # [win]
-    - accelerate --help
-    - accelerate-config --help
-    - accelerate-launch --help
-    - accelerate-estimate-memory --help
-    - accelerate-merge-weights --help
-    # Run CPU-safe upstream tests; GPU/TPU/distributed tests are auto-skipped
-    # by upstream decorators (require_non_cpu, require_tpu, etc.).
-    # Omit files that require optional heavy deps (bitsandbytes, FP8, trackers,
-    # SageMaker, DeepSpeed, FSDP, TP) or full training examples.
-    - pytest {{ test_files }} -v --no-header -rf {{ skip_compile }}
+    - setuptools
+    - wheel
+  run:
+    - python
+
+outputs:
+  - name: {{ name|lower }}
+    build:
+      entry_points:
+        - accelerate=accelerate.commands.accelerate_cli:main
+        - accelerate-config=accelerate.commands.config:main
+        - accelerate-estimate-memory=accelerate.commands.estimate:main
+        - accelerate-launch=accelerate.commands.launch:main
+        - accelerate-merge-weights=accelerate.commands.merge:main
+      script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+    requirements:
+      host:
+        - python
+        - pip
+        - setuptools
+        - wheel
+      run:
+        - python
+        - numpy >=1.17
+        - packaging >=20.0
+        - psutil
+        - pytorch >=2.0.0  # [linux]
+        # pytorch first built with USE_DISTRIBUTED=1 at v2.0.1 for win/osx.
+        - pytorch >=2.0.1  # [win or osx]
+        - huggingface_hub >=0.21.0
+        - pyyaml
+        - safetensors >=0.4.3
+    test:
+      source_files:
+        - tests/
+      requires:
+        - pip
+        - pytest
+        - parameterized
+        - cxx-compiler
+      imports:
+        - accelerate
+      commands:
+        - pip check
+        - set "PYTHONIOENCODING=utf8"  # [win]
+        - accelerate --help
+        - accelerate-config --help
+        - accelerate-launch --help
+        - accelerate-estimate-memory --help
+        - accelerate-merge-weights --help
+        # Run CPU-safe upstream tests; GPU/TPU/distributed tests are auto-skipped
+        # by upstream decorators (require_non_cpu, require_tpu, etc.).
+        # Omit files that require optional heavy deps (bitsandbytes, FP8, trackers,
+        # SageMaker, DeepSpeed, FSDP, TP) or full training examples.
+        - pytest {{ test_files }} -v --no-header -rf {{ skip_compile }}
+
+  # Keep the original output for backwards compatibility.
+  - name: huggingface_{{ name|lower }}
+    requirements:
+      run:
+        - {{ pin_subpackage(name|lower, exact=True) }}
+    test:
+      imports:
+        - accelerate
 
 about:
   home: https://github.com/huggingface/accelerate


### PR DESCRIPTION
accelerate rebuild

**Destination channel:** defaults

### Links

- [PKG-14666](https://anaconda.atlassian.net/browse/PKG-14666) 

### Explanation of changes:

- Convert this to a multi-output recipe. Output the original `huggingface_accelerate` and add `accelerate` to match pypi/conda-forge

### Notes
- The diff looks like more changed then actually did. Tests, test skips etc all remained the same. 


[PKG-14666]: https://anaconda.atlassian.net/browse/PKG-14666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ