### PR TITLE
accelerate 1.11.0 build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "accelerate" %}
-{% set version = "1.13.0" %}
+{% set version = "1.11.0" %}
 
 
 {% set skip_compile = "" %}
@@ -24,10 +24,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236
+  sha256: bb1caf2597b4cd632b917b5000c591d10730bb024a79746f1ee205bba80bd229
 
 build:
-  number: 1
+  number: 0
   skip: true  # [py<310]
 
 requirements:


### PR DESCRIPTION
## accelerate 1.11.0 (version-specific branch build)

**Destination channel:** defaults
**Base branch:** 1.11.0 (NOT main)

### Links

- [PKG-14886](https://anaconda.atlassian.net/browse/PKG-14886) — required by llamafactory 0.9.5
- Upstream: https://github.com/huggingface/accelerate/releases/tag/v1.11.0

### Explanation of changes:

- Build older accelerate 1.11.0 on a version-specific branch. pkgs/main currently has accelerate 1.13.0 only; llamafactory 0.9.5 pins `accelerate<=1.11.0`. Per Charles's review on llamafactory#1, we ship the older sibling version alongside 1.13.0 instead of relaxing the cap.
- conda solver picks 1.13.0 for consumers without an upper bound, and 1.11.0 for llamafactory which pins below.
- Recipe identical to main's; only version + sha256 changed; build number 1 to differentiate from any prior 1.11.0 _0 artifacts.

[PKG-14886]: https://anaconda.atlassian.net/browse/PKG-14886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ